### PR TITLE
chore: setup GitHub Codespace configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm"
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
+    "postCreateCommand": "npm install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,11 @@
 {
     "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
-    "postCreateCommand": "npm install"
+    "postCreateCommand": "npm install",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "GitHub.vscode-github-actions"
+            ]
+        }
+    }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Setting up your development environment
+
+The recommended way to setup your development environment for this repo is to open it in a
+[GitHub Codespace](https://github.com/features/codespaces).
+
+Some of the benefits of using Codespaces for the IDE include:
+
+- ensures that everyone contributing to the code has exactly the same local development configured
+- ensures that the local development environment is documented via configuration as code
+- allows anyone contributing to the code for the first time to get up and running quickly and easily
+
+### Codespace requirements
+
+Literally all you need is either:
+- a web browser, or
+- VS Code (recommended)
+
+[Web browser Codespaces documentation](https://docs.github.com/en/codespaces/developing-in-a-codespace/developing-in-a-codespace?tool=webui#working-in-a-codespace-in-the-browser)
+
+[VS Code Codespaces documentation](https://docs.github.com/en/codespaces/developing-in-a-codespace/developing-in-a-codespace?tool=vscode#working-in-a-codespace-in-vs-code)
+
+All you need to do is click on the green `<> Code` dropdown button on the 
+[GitHub repo page](https://github.com/tobyurff/coliving-semkovo),
+and then choose: `Create codespace on main`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Coliving Semkovo
+
+## How to contribute
+
+See the [Contributing guide](./CONTRIBUTING.md)


### PR DESCRIPTION
- Add [dev container configuration][1] so that we can use [GitHub Codespaces][2] as an IDE.  Using a Codespace as our IDE ensures that everyone contributing to the code has exactly the same local development configured, ensures that the local development environment is documented via configuration as code, and also allows anyone contributing to the code for the first time to get up and running quickly and easily.

  Use the [standard Node with Typescript devcontainer image][3], which is [listed as a template on containers.dev][4].

- Install npm modules on devcontainer start

- Add GitHub Actions extension on codespace
  The [GitHub Actions VS Code extension][5] lets you manage your GitHub Actions workflows, view the workflow run history, and helps with authoring workflows.

[1]: https://containers.dev/
[2]: https://github.com/features/codespaces
[3]: https://github.com/devcontainers/templates/tree/main/src/typescript-node
[4]: https://containers.dev/templates
[5]: https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions