### PR TITLE
Run playwright tests on push to any branch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,10 +1,6 @@
 name: Playwright Tests
 on:
   push:
-    branches:
-      - main
-      - master
-      - develop
   pull_request: null
   workflow_dispatch: null
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,5 @@
 name: Playwright Tests
-on:
-  push:
-  pull_request: null
-  workflow_dispatch: null
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
Quick feedback is a good thing, especially when running tests.  Run the Playwright tests on pushes to any branch, so we can verify the tests pass in the CI pipeline before creating a pull request.