### PR TITLE
fix: fix build by using package.json Biome version

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Biome
+        # By not specifying a version here we automatically use the version in package.json instead
+        # (see https://github.com/marketplace/actions/setup-biome#automatic-version-detection)
         uses: biomejs/setup-biome@v2
-        with:
-          version: latest
       - name: Run Biome
         run: biome ci .


### PR DESCRIPTION
Prior to this commit the Biome GitHub Action (used for CI) was set to `latest`.  This [caused the build to fail][1], becuase it automatically picked up the new [1.6.0][2] version, which has some new checks.

Fix is to no longer specify a Biome version at all in the GitHub Action, meaning that the Action falls back to [automatic version detection][3], using the version in the `package.json`.  This is much better as not only does it fix our build issue but it also guarantees Biome version consistency between our Codespace development environment (i.e the Biome version used by the Codespace Biome VS Code extension) and in CI.

[1]: https://github.com/coliving-semkovo/coliving-semkovo/issues/8
[2]: https://github.com/biomejs/biome/releases/tag/cli%2Fv1.6.0
[3]: https://github.com/marketplace/actions/setup-biome#automatic-version-detection

