### PR TITLE
Feature: Add running Next.js in dev mode as part of devcontainer startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
-    "postCreateCommand": "npm install && npx playwright install-deps && npx playwright install",
+    "postCreateCommand": "npm install && npx playwright install-deps && npx playwright install && npm run dev",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
Once the container is done setup, to get started developing you'll run Next.js in dev mode 99% of the time, so I feel it's helpful to just have that factored into the build process.