### PR TITLE
chore: install Postgres VS Code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
             "extensions": [
                 "GitHub.vscode-github-actions",
                 "ms-playwright.playwright",
-                "biomejs.biome"
+                "biomejs.biome",
+                "ckolkman.vscode-postgres"
             ],
             "settings": {
                 // https://biomejs.dev/reference/vscode/#default-formatter


### PR DESCRIPTION
Decided to use [Chris Kolkman's extension][1], rather than the [official Microsoft extension][2], as the Microsoft one did not install successfully on our Codespace when we tried it.  It also has terrible reviews and does not seem to be actively maintained ([last commit was 9 months ago][3]).

[1]: https://marketplace.visualstudio.com/items?itemName=ckolkman.vscode-postgres
[2]: https://marketplace.visualstudio.com/items?itemName=ms-ossdata.vscode-postgresql
[3]: https://github.com/microsoft/vscode-postgresql/commits/master/

