### PR TITLE
chore: add PostgreSQL to Codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# [Choice] Node & Debian OS versions: 20-bookworm, 18-bookworm, 20-bullseye, 18-bullseye, 20-buster, 18-buster
+ARG VARIANT="20-bullseye"
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,40 @@
+
+# Node.js, TypeScript & PostgreSQL (javascript-node-postgres)
+
+Develop Node.js based applications in TypeScript, with PostgreSQL as the database. Includes Node.js and TypeScript in a container linked to a Postgres DB container.
+
+## Using this devcontainer definition
+
+The definition is almost exactly the same as the [standard Node.js & PostgreSQL template](https://github.com/devcontainers/templates/tree/main/src/javascript-node-postgres), with the only differences being that the underlying container image is
+the [Node.js and TypesScript image](https://github.com/devcontainers/images/tree/main/src/typescript-node) rather than the [Node.js image](https://github.com/devcontainers/images/tree/main/src/javascript-node).
+
+This definition creates two containers, one for Node.js with TypeScript, and one for PostgreSQL. You will be connected to the Node.js with TypeScript container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.
+
+While the definition itself works unmodified, it uses the `mcr.microsoft.com/devcontainers/typescript-node` image which includes `git`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
+
+You also can connect to PostgreSQL from an external tool when connected to the Dev Container from a local tool  by updating `.devcontainer/devcontainer.json` as follows:
+
+```json
+"forwardPorts": [ "5432" ]
+```
+
+### Adding another service
+
+You can add other services to your `docker-compose.yml` file [as described in Docker's documentaiton](https://docs.docker.com/compose/compose-file/#service-configuration-reference). However, if you want anything running in this service to be available in the container on localhost, or want to forward the service locally, be sure to add this line to the service config:
+
+```yaml
+# Runs the service on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+network_mode: service:db
+```
+
+### Using the forwardPorts property
+
+By default, web frameworks and tools often only listen to localhost inside the container. As a result, we recommend using the `forwardPorts` property to make these ports available locally.
+
+```json
+"forwardPorts": [9000]
+```
+
+The `ports` property in `docker-compose.yml` [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port. This will not work in a cloud environment like Codespaces and applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. Fortunately the `forwardPorts` property does not have this limitation.
+
+---

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bookworm",
+    "name": "Node.js, TypeScript & PostgreSQL",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "postCreateCommand": "npm install && npx playwright install-deps && npx playwright install",
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  app:
+    build: 
+      context: .
+      dockerfile: Dockerfile
+      # [Optional] You can use build args to set options. e.g. 'VARIANT' below affects the image in the Dockerfile
+      args: 
+        VARIANT: 20-bookworm
+
+    volumes:
+      - ../..:/workspaces:cached
+      
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  postgres-data:
+  


### PR DESCRIPTION
Adding PostgreSQL to our Codespace led us to modify our definition to use two containers rather than one.  In addition to the Node.js with TypeScript container which we were already using, we now also have a PostgreSQL DB container. Having two containers means that we now also use [Docker Compose][1] to manage them.

The documentation for how to use the PostgreSQL database is in the README in the `.devcontainer` directory.

[1]: https://docs.docker.com/compose/

