### PR TITLE
chore: add Prisma VS Code extension to Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
                 "GitHub.vscode-github-actions",
                 "ms-playwright.playwright",
                 "biomejs.biome",
-                "ckolkman.vscode-postgres"
+                "ckolkman.vscode-postgres",
+                "Prisma.prisma"
             ],
             "settings": {
                 // https://biomejs.dev/reference/vscode/#default-formatter


### PR DESCRIPTION
We use Prisma as our ORM, so it's good to have the [Prisma VS Code extension][1] installed, to make it easier to work with the [Prisma schema file][2], etc.

[1]: https://marketplace.visualstudio.com/items?itemName=Prisma.prisma
[2]: https://www.prisma.io/docs/orm/prisma-schema

