### PR TITLE
chore: setup database on Codespace, via Prisma

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
     "dockerComposeFile": "docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-    "postCreateCommand": "npm install && npx playwright install-deps && npx playwright install",
+    "postCreateCommand": "npm install && npx prisma migrate reset -f && npx playwright install-deps && npx playwright install",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
We run Prisma's `migrate reset` command rather than  `migrate dev`, as reset additionally seeds the database, which is the behaviour we want when opening a new Codespace (we don't have any database seed scripts right now, but we may do in the future).

