### PR TITLE
chore: ensure that only maintainers approve PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @these owners will be requested for
+# review when someone opens a pull request.
+*       @tobyurff @johnboyes


### PR DESCRIPTION
We only want project maintainers to be able to approve PRs.  For instance we don't want the `coliving-semkovo` GitHub account to be able to approve PRs.  We achieve this via the [`CODEOWNERS`][1] file, together with enabling the [protected branch setting][2] which requires each PR to be reviewed and approved by a `CODEOWNER`.

[1]: https://help.github.com/articles/about-codeowners/
[2]: https://help.github.com/articles/about-protected-branches/

