### PR TITLE
chore: check env vars at build time

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Install playwright browsers
         run: npx playwright install --with-deps
       - name: Run tests
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npm run e2e
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,4 +11,6 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Tests
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npm run test

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+require("./src/server/config.js");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	images: {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,0 +1,10 @@
+// @ts-check
+const { z } = require("zod");
+
+const Config = z.object({
+	DATABASE_URL: z.string(),
+});
+
+const config = Config.parse(process.env);
+
+module.exports.config = config;

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,6 +1,12 @@
 // @ts-check
 const { z } = require("zod");
 
+if (typeof window !== "undefined") {
+	throw new Error(
+		"src/server/config.js must not be imported on the frontend (as it validates server-side vars).",
+	);
+}
+
 const Config = z.object({
 	DATABASE_URL: z.string(),
 });

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -8,7 +8,9 @@ if (typeof window !== "undefined") {
 }
 
 const Config = z.object({
-	DATABASE_URL: z.string(),
+	DATABASE_URL: z.string().regex(/^(postgres|postgresql):\/\//, {
+		message: "DATABASE_URL is not a valid postgres connection string",
+	}),
 });
 
 const config = Config.parse(process.env);


### PR DESCRIPTION
We were already following [12 factor principles][1] by [storing our config in the environment][2].  Because we store our config in the environment it is important to validate that there are no missing environment variables, and also ideally to validate that they are in the expected format (e.g. a database URL is properly formatted) where appropriate.

Prior to this commit we were not validating our environment config. We now check that all required environment variables are present.  We validate this at build time as we want to fail fast if there are any problems, rather than deploying a misconfigured app to our customers (which would happen if we only validated our config at runtime, or didn't validate at all).

We followed [the initial step in this excellent article][3] to achieve this. NB the article suggests doing some fairly fancy stuff to check required client env vars, not just server-side, but that seems unnecessary as we can just check on the server-side for any required `NEXT_PUBLIC_` env vars, and rely on Next.js to expose them client-side.

[1]: https://12factor.net/
[2]: https://12factor.net/config
[3]: https://sophiabits.com/blog/verify-environment-variables-nextjs