### PR TITLE
chore: add checkjs error reporting for js files

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -3,9 +3,13 @@ import { z } from "zod";
 
 export const env = createEnv({
 	server: {
+		// @ts-ignore: TODO: investigate and fix the TypeScript check error
 		NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
+		// @ts-ignore: TODO: investigate and fix the TypeScript check error
 		NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION_ID: z.string().min(1).optional(),
+		// @ts-ignore: TODO: investigate and fix the TypeScript check error
 		NEXT_PUBLIC_GITHUB_ID: z.string().min(1).optional(),
+		// @ts-ignore: TODO: investigate and fix the TypeScript check error
 		NEXT_PUBLIC_GITHUB_SECRET: z.string().min(1).optional(),
 	},
 	runtimeEnv: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"types": ["@testing-library/jest-dom"],
 		"allowJs": true,
+		"checkJs": true,
 		"skipLibCheck": true,
 		"strict": true,
 		"noEmit": true,


### PR DESCRIPTION
Having error reporting for js files is a good thing, so good to enable this via [checkjs][1].
The `env.mjs` file failed the error checking, complaining that the vars prefixed with `NEXT_PUBLIC_` should not have this prefix, for some reason. So we exclude those lines from the error checking for now, and will investigate and hopefully fix them at a later point.

[1]: https://www.typescriptlang.org/tsconfig#checkJs

