### PR TITLE
fix: remove eslint import sorting to fix Vercel

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		"plugin:@typescript-eslint/recommended",
 		"plugin:tailwindcss/recommended",
 	],
-	plugins: ["simple-import-sort", "@typescript-eslint"],
+	plugins: ["@typescript-eslint"],
 	rules: {
 		"sort-imports": "off",
 		// turned off mixed spaces and tabs checking as it was conflicting with Biome,
@@ -15,22 +15,6 @@ module.exports = {
 		"no-mixed-spaces-and-tabs": "off",
 		"tailwindcss/no-custom-classname": "off",
 		"@typescript-eslint/no-var-requires": "off",
-		"simple-import-sort/imports": [
-			2,
-			{
-				groups: [
-					["^.+\\.s?css$"],
-					[
-						`^(${require("node:module").builtinModules.join("|")})(/|$)`,
-						"^react",
-						"^@?\\w",
-					],
-					["^components(/.*|$)"],
-					["^lib(/.*|$)", "^hooks(/.*|$)"],
-					["^\\."],
-				],
-			},
-		],
 	},
 	settings: {
 		tailwindcss: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
 				"eslint-config-next": "14.1.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-prettier": "^5.1.3",
-				"eslint-plugin-simple-import-sort": "^12.0.0",
 				"eslint-plugin-tailwindcss": "^3.14.2",
 				"husky": "^9.0.11",
 				"jest": "^29.7.0",
@@ -5813,15 +5812,6 @@
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/eslint-plugin-simple-import-sort": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
-			"integrity": "sha512-8o0dVEdAkYap0Cn5kNeklaKcT1nUsa3LITWEuFk3nJifOoD+5JQGoyDUW2W/iPWwBsNBJpyJS9y4je/BgxLcyQ==",
-			"dev": true,
-			"peerDependencies": {
-				"eslint": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 		"eslint-config-next": "14.1.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-prettier": "^5.1.3",
-		"eslint-plugin-simple-import-sort": "^12.0.0",
 		"eslint-plugin-tailwindcss": "^3.14.2",
 		"husky": "^9.0.11",
 		"jest": "^29.7.0",


### PR DESCRIPTION
Vercel deploys were failing because the eslint import sorting check was failing.  Fix is to remove eslint import sorting altogether, as our strategy is to [enable Biome's import sorting][1] instead, in due course.

[1]: https://github.com/coliving-semkovo/coliving-semkovo/issues/34

